### PR TITLE
Revert "Bump filelock from 3.7.1 to 3.8.0 (#39)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ click==8.1.3
 coverage==6.4.3
 distlib==0.3.5
 docutils==0.17.1
-filelock==3.8.0
+filelock==3.7.1
 flake8==5.0.4
 flake8-isort==4.2.0
 flake8-pyi==22.8.1


### PR DESCRIPTION
Reverts erroneous merge during degraded performance of github actions leading to incorrect CI reporting